### PR TITLE
Improve zooming behiavior, support map.flyTo (`zoom` + `zoomanim` events)

### DIFF
--- a/lib/CanvasLayer.js
+++ b/lib/CanvasLayer.js
@@ -25,10 +25,8 @@ var CanvasLayer = reactLeaflet.withLeaflet((_temp = _class = class CanvasLayer e
     const canAnimate = this.props.leaflet.map.options.zoomAnimation && L.Browser.any3d;
     const zoomClass = `leaflet-zoom-${canAnimate ? 'animated' : 'hide'}`;
     const mapSize = this.props.leaflet.map.getSize();
-    const transformProp = L.DomUtil.testProp(['transformOrigin', 'WebkitTransformOrigin', 'msTransformOrigin']);
 
     this._el = L.DomUtil.create('canvas', zoomClass);
-    this._el.style[transformProp] = '50% 50%';
     this._el.width = mapSize.x;
     this._el.height = mapSize.y;
 
@@ -68,23 +66,38 @@ var CanvasLayer = reactLeaflet.withLeaflet((_temp = _class = class CanvasLayer e
     leafletMap.on('viewreset', () => this.reset());
     leafletMap.on('moveend', () => this.reset());
     if (leafletMap.options.zoomAnimation && L.Browser.any3d) {
-      leafletMap.on('zoomanim', this._animateZoom, this);
+      leafletMap.on('zoom', this._onZoom, this);
+      leafletMap.on('zoomanim', this._onAnimZoom, this);
     }
   }
 
-  _animateZoom(e) {
-    const scale = this.props.leaflet.map.getZoomScale(e.zoom);
-    const offset = this.props.leaflet.map._getCenterOffset(e.center)._multiplyBy(-scale).subtract(this.props.leaflet.map._getMapPanePos());
+  _onAnimZoom(ev) {
+    this._updateTransform(ev.center, ev.zoom);
+  }
 
-    if (L.DomUtil.setTransform) {
-      L.DomUtil.setTransform(this._el, offset, scale);
-    } else {
-      this._el.style[L.DomUtil.TRANSFORM] = `${L.DomUtil.getTranslateString(offset)} scale(${scale})`;
-    }
+  _onZoom() {
+    const map = this.props.leaflet.map;
+    this._updateTransform(map.getCenter(), map.getZoom());
+  }
+
+  _updateTransform(center, zoom) {
+    const map = this.props.leaflet.map;
+
+    const scale = map.getZoomScale(zoom, this._zoom),
+          position = L.DomUtil.getPosition(this._el),
+          viewHalf = map.getSize().multiplyBy(0.5),
+          currentCenterPoint = map.project(this._center, zoom),
+          destCenterPoint = map.project(center, zoom),
+          centerOffset = destCenterPoint.subtract(currentCenterPoint);
+
+    const topLeftOffset = viewHalf.multiplyBy(-scale).add(position).add(viewHalf).subtract(centerOffset);
+
+    L.DomUtil.setTransform(this._el, topLeftOffset, scale);
   }
 
   reset() {
-    const topLeft = this.props.leaflet.map.containerPointToLayerPoint([0, 0]);
+    const map = this.props.leaflet.map;
+    const topLeft = map.containerPointToLayerPoint([0, 0]);
     L.DomUtil.setPosition(this._el, topLeft);
 
     const size = this.props.leaflet.map.getSize();
@@ -101,6 +114,9 @@ var CanvasLayer = reactLeaflet.withLeaflet((_temp = _class = class CanvasLayer e
     }
 
     this.redraw();
+
+    this._center = map.getCenter();
+    this._zoom = map.getZoom();
   }
 
   redraw() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-leaflet-canvas-layer",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A canvas layer for react-leaflet",
   "main": "index.js",
   "files": [
@@ -34,12 +34,13 @@
     "babel-plugin-transform-react-jsx": "^6.24.1",
     "babel-preset-env": "^1.7.0",
     "babel-preset-react": "^6.24.1",
+    "css-loader": "^1.0.0",
+    "rollup": "^1.7.0",
     "rollup-plugin-babel": "^3.0.7",
     "rollup-plugin-node-resolve": "^3.4.0",
     "url-loader": "^1.1.1",
     "webpack": "^4.1.0",
     "webpack-cli": "^2.0.14",
-    "webpack-dev-server": "^3.1.3",
-    "css-loader": "^1.0.0"
+    "webpack-dev-server": "^3.1.3"
   }
 }


### PR DESCRIPTION
This PR improves behavior when `map.flyTo` is being used. Previously, the canvas layer wasn't nicely animated. 

The new implementation is based on:
https://github.com/Leaflet/Leaflet/blob/37d2fd15ad6518c254fae3e033177e96c48b5012/src/layer/vector/Renderer.js#L82-L105
